### PR TITLE
Upgrade Gitlab chart

### DIFF
--- a/charts/gitlab-omnibus/Chart.yaml
+++ b/charts/gitlab-omnibus/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 14.2.3-ee.0
+appVersion: 14.6.1-ee.0

--- a/charts/gitlab-omnibus/README.md
+++ b/charts/gitlab-omnibus/README.md
@@ -99,7 +99,7 @@ The chart offers the following list of configuration values.
 
 ## Upgrade Instructions
 
-When updating from version `0.1.1` (Gitlab 13.10.2) to version `0.3.0` (Gitlab 14.2.3), follow the upgrade path:
+When updating from version `0.1.1` (Gitlab 13.10.2) to version `0.3.0` (Gitlab 14.6.1), follow the upgrade path:
 
 1. Chart version `0.1.1` with default `image.tag`.
 2. Chart version `0.1.1` with `image.tag`=`13.12.11-ee.0`.

--- a/charts/gitlab-omnibus/README.md
+++ b/charts/gitlab-omnibus/README.md
@@ -72,8 +72,10 @@ The chart offers the following list of configuration values.
 | `volumeClaims.data.selector` | Data persistent volume claim selector. |
 | `securityContext` | Container security context. |
 | `service` | Service related options. |
-| `service.port` | Service target port. |
-| `service.type` | Service type. |
+| `httpService.port` | HTTP Service port. |
+| `httpService.type` | HTTP Service type. |
+| `sshService.port` | SSH Service port. |
+| `sshService.type` | SSH Service type. |
 | `ingress` | Ingress related options. |
 | `ingress.enabled` | Enable ingress creation. |
 | `ingress.hosts` | Ingress hosts. |
@@ -97,7 +99,7 @@ The chart offers the following list of configuration values.
 
 ## Upgrade Instructions
 
-When updating from version `0.1.1` (Gitlab 13.10.2) to version `0.2.0` (Gitlab 14.2.3), follow the upgrade path:
+When updating from version `0.1.1` (Gitlab 13.10.2) to version `0.3.0` (Gitlab 14.2.3), follow the upgrade path:
 
 1. Chart version `0.1.1` with default `image.tag`.
 2. Chart version `0.1.1` with `image.tag`=`13.12.11-ee.0`.
@@ -105,6 +107,7 @@ When updating from version `0.1.1` (Gitlab 13.10.2) to version `0.2.0` (Gitlab 1
 4. Chart version `0.1.1` with `image.tag`=`14.1.5-ee.0`.
 5. Chart version `0.1.1` with `image.tag`=`14.2.3-ee.0`. Wait for background migrations to finish.
 6. Chart version `0.2.0` with default `image.tag`. Gitlab Pages should work.
+7. Chart version `0.3.0` with default `image.tag`.
 
 [Check out upgrade paths documentation](https://docs.gitlab.com/ee/update/index.html#upgrade-paths) for more information.
 

--- a/charts/gitlab-omnibus/templates/deployment.yaml
+++ b/charts/gitlab-omnibus/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+            - name: ssh
+              containerPort: 22
+              protocol: TCP
             - name: wh-metrics  
               containerPort: {{ .Values.metrics.workhorse.port }}
               protocol: TCP

--- a/charts/gitlab-omnibus/templates/ingress.yaml
+++ b/charts/gitlab-omnibus/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "gitlab-omnibus.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/gitlab-omnibus/templates/service.yaml
+++ b/charts/gitlab-omnibus/templates/service.yaml
@@ -5,13 +5,31 @@ metadata:
   labels:
     {{- include "gitlab-omnibus.labels" . | nindent 4 }}
 spec:
-  {{- with .Values.service.type }}
+  {{- with .Values.httpService.type }}
   type: {{ . }}
   {{- end }}
   ports:
-    - port: 80
-      targetPort: {{ .Values.service.port }}
+    - port: {{ .Values.httpService.port }}
+      targetPort: http
       protocol: TCP
       name: http
+  selector:
+    {{- include "gitlab-omnibus.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gitlab-omnibus.fullname" . }}-ssh
+  labels:
+    {{- include "gitlab-omnibus.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.sshService.type }}
+  type: {{ . }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.sshService.port }}
+      targetPort: ssh
+      protocol: TCP
+      name: ssh
   selector:
     {{- include "gitlab-omnibus.selectorLabels" . | nindent 4 }}

--- a/charts/gitlab-omnibus/values.yaml
+++ b/charts/gitlab-omnibus/values.yaml
@@ -50,9 +50,13 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-service:
+httpService:
   # type: ClusterIP
   port: 80
+
+sshService:
+  type: LoadBalancer
+  port: 22
 
 ingress:
   enabled: true


### PR DESCRIPTION
Upgrade Gitlab version and add Service of type LoadBalancer to expose Gitlab's port 22 for SSH connections.